### PR TITLE
Disallow duplicate strats

### DIFF
--- a/lib/d2_crucible_roulette_web/templates/page/strat_component.ex
+++ b/lib/d2_crucible_roulette_web/templates/page/strat_component.ex
@@ -10,7 +10,7 @@ defmodule D2CrucibleRouletteWeb.StratComponent do
     ~H"""
     <div class="card">
       <header class="card-header">
-        <p class="card-header-title">
+        <p class="card-header-title strat-name">
           <%= @strat.name %>
         </p>
       </header>

--- a/test/d2_crucible_roulette_web/templates/page/page_live_test.exs
+++ b/test/d2_crucible_roulette_web/templates/page/page_live_test.exs
@@ -40,4 +40,12 @@ defmodule D2CrucibleRouletteWeb.PageLiveTest do
     assert render_click(view, :dislike, %{"id" => strat.id}) =~
              "<span>#{strat.dislikes + 1}</span>"
   end
+
+  test "a strat will not be duplicated", ~M{conn} do
+    insert_list(3, :strat)
+    {:ok, view, _html} = live(conn, "/")
+    first_strat = element(view, ".strat-name") |> render()
+    render_click(view, :fetch)
+    refute element(view, ".strat-name") |> render() == first_strat
+  end
 end


### PR DESCRIPTION
Closes #6

Lookup the strat in the strat history before displaying a new strat.
Refactors push_history to use the currently displayed strat which means the history will be empty on load﻿
