### PR TITLE
maintain session data

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -26,8 +26,32 @@ import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
 import topbar from "../vendor/topbar"
 
+let Hooks = {}
+
+Hooks.Restore = {
+  mounted() {
+    currentStrat = sessionStorage.getItem("currentStrat")
+    currentHistory = sessionStorage.getItem("currentHistory")
+    this.pushEvent("restore", {currentStrat: currentStrat, currentHistory: currentHistory})
+  }
+}
+
+Hooks.setCurrent = {
+  updated() {
+    this.handleEvent("setCurrent", ({ history }) =>
+      sessionStorage.setItem("currentHistory", history)
+    )
+    this.handleEvent("setCurrent", ({ strat }) =>
+      sessionStorage.setItem("currentStrat", strat)
+    )
+  }
+}
+
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
-let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}})
+let liveSocket = new LiveSocket("/live", Socket, {
+  params: {_csrf_token: csrfToken},
+  hooks: Hooks,
+})
 
 // Show progress bar on live navigation and form submits
 topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})
@@ -44,22 +68,16 @@ liveSocket.connect()
 window.liveSocket = liveSocket
 
 document.addEventListener('DOMContentLoaded', () => {
-
-  // Get all "navbar-burger" elements
   const $navbarBurgers = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0);
 
-  // Check if there are any navbar burgers
   if ($navbarBurgers.length > 0) {
 
-    // Add a click event on each of them
     $navbarBurgers.forEach( el => {
       el.addEventListener('click', () => {
 
-        // Get the target from the "data-target" attribute
         const target = el.dataset.target;
         const $target = document.getElementById(target);
 
-        // Toggle the "is-active" class on both the "navbar-burger" and the "navbar-menu"
         el.classList.toggle('is-active');
         $target.classList.toggle('is-active');
 

--- a/lib/d2_crucible_roulette/strats/strat.ex
+++ b/lib/d2_crucible_roulette/strats/strat.ex
@@ -2,6 +2,8 @@ defmodule D2CrucibleRoulette.Strats.Strat do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @derive {Jason.Encoder, only: [:name, :description, :author, :likes, :dislikes, :id]}
+
   @moduledoc """
   Strat represents what and how a strat is represented in the database
   """
@@ -20,3 +22,11 @@ defmodule D2CrucibleRoulette.Strats.Strat do
     |> validate_required([:name, :description, :author])
   end
 end
+
+# defimpl Jason.Encoder, for: D2CrucibleRoulette.Strats.Strat do
+#   def encode(strat, opts) do
+#     strat
+#     |> Map.from_struct()
+#     |> Jason.Encode.map(opts)
+#   end
+# end

--- a/lib/d2_crucible_roulette_web/templates/page/page_live.ex
+++ b/lib/d2_crucible_roulette_web/templates/page/page_live.ex
@@ -53,7 +53,8 @@ defmodule D2CrucibleRouletteWeb.PageLive do
 
 
   Restore handles the `restore` event which restores session data containing the current strat and the strat history
-  Sets the current strat and history to what is stored in the sessionStorage
+  Sets the current strat and history to what is stored in the sessionStorage.
+  If currentStrat is nil, then we continue on as normal
   """
   @impl Phoenix.LiveView
   def handle_event("fetch", _session, socket) do
@@ -74,6 +75,7 @@ defmodule D2CrucibleRouletteWeb.PageLive do
   def handle_event("like", %{"id" => strat_id}, socket) do
     case Strats.like(strat_id) do
       {:ok, strat} ->
+        Process.send(self(), {:save, strat, socket.assigns.history}, [])
         socket = assign(socket, strat: strat)
         {:noreply, socket}
 
@@ -86,6 +88,7 @@ defmodule D2CrucibleRouletteWeb.PageLive do
   def handle_event("dislike", %{"id" => strat_id}, socket) do
     case Strats.dislike(strat_id) do
       {:ok, strat} ->
+        Process.send(self(), {:save, strat, socket.assigns.history}, [])
         socket = assign(socket, strat: strat)
         {:noreply, socket}
 

--- a/lib/d2_crucible_roulette_web/templates/page/strat_component.ex
+++ b/lib/d2_crucible_roulette_web/templates/page/strat_component.ex
@@ -8,7 +8,7 @@ defmodule D2CrucibleRouletteWeb.StratComponent do
   @impl Phoenix.LiveComponent
   def render(assigns) do
     ~H"""
-    <div class="card">
+    <div class="card" id={"strat-@strat.id"} phx-hook="setCurrent" >
       <header class="card-header">
         <p class="card-header-title strat-name">
           <%= @strat.name %>


### PR DESCRIPTION
Closes #33

- Basic strat and history session storage
- Update session storage after liking/disliking a strat
- Save strat id in session storage allows a lookup to get the most up to date info
